### PR TITLE
ci(workflows): bump GitHub Actions versions in push-ghcr workflow

### DIFF
--- a/.github/workflows/push-ghcr.yml
+++ b/.github/workflows/push-ghcr.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Derive Image Name
         id: image
@@ -26,7 +26,7 @@ jobs:
           echo "name=${GITHUB_REPOSITORY##*/}" >> $GITHUB_OUTPUT
 
       - name: Sign in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ steps.image.outputs.name }}
           tags: |
@@ -42,10 +42,10 @@ jobs:
             type=sha,format=short
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push image to GHCR
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
- actions/checkout: v4 → v5
- docker/login-action: v3 → v4
- docker/metadata-action: v5 → v6
- docker/setup-buildx-action: v3 → v4
- docker/build-push-action: v5 → v7